### PR TITLE
New commands to fetch key details

### DIFF
--- a/openpgp-dsm/src/lib.rs
+++ b/openpgp-dsm/src/lib.rs
@@ -985,7 +985,11 @@ pub fn list_keys(cred: Credentials) -> Result<Vec<DsmKeyInfo>> {
 
         for key_details in dsm_client.list_sobjects(Some(&params))?
             .iter()
-            .filter(|key| filter_pgp_keys(key))
+            .filter(|key|
+                    match &key.custom_metadata {
+                        Some(metadata) => metadata.contains_key(&DSM_LABEL_PGP.to_string()),
+                        None => false,
+                    })
             .map(|key| DsmKeyInfo::from(key)) {
             key_info_store.push(key_details);
         }
@@ -994,13 +998,6 @@ pub fn list_keys(cred: Credentials) -> Result<Vec<DsmKeyInfo>> {
     Ok(key_info_store)
 }
 
-/// Filter keys which do not have PGP signature/metadata
-fn filter_pgp_keys(key: &Sobject) -> bool {
-    match &key.custom_metadata {
-        Some(metadata) => metadata.contains_key(&DSM_LABEL_PGP.to_string()),
-        None => false,
-    }
-}
 /// Extracts the certificate of the corresponding PGP key. Note that this
 /// certificate, created at key-generation time, is stored in the custom
 /// metadata of the Security Object representing the primary key.

--- a/sq/Makefile
+++ b/sq/Makefile
@@ -37,6 +37,7 @@ install: build-release
 
 test-dsm:
 	cargo build
+	./tests/dsm/print_dsm_key_info.sh
 	./tests/dsm/knownkeys_import_dsm.sh
 	./tests/dsm/generate_gpg_import_dsm_auto.tcl
 	./tests/dsm/key_expiration.sh -c rsa2k

--- a/sq/src/commands/key.rs
+++ b/sq/src/commands/key.rs
@@ -344,7 +344,7 @@ fn print_dsm_key_info(_config: Config, m: &ArgMatches) -> Result<()> {
     };
 
     print!("{}\n",output.iter()
-           .map(|key| key.sobject_long_details_formatter())
+           .map(|key| key.format_details_long())
            .join("\n"));
 
     Ok(())
@@ -374,9 +374,9 @@ fn list_dsm_keys(_config: Config, m: &ArgMatches) -> Result<()> {
                .iter()
                .map( |key|
                      if verbose {
-                         key.sobject_long_details_formatter()
+                         key.format_details_long()
                      }else {
-                         key.sobject_short_details_formatter()
+                         key.format_details_short()
                      })
                .join("\n"),
            footer = format!("\nTOTAL OBJECTS: {}\n", output.len()),

--- a/sq/src/commands/key.rs
+++ b/sq/src/commands/key.rs
@@ -18,9 +18,7 @@ use crate::openpgp::types::SignatureType;
 
 use openpgp_dsm as dsm;
 
-use crate::{
-    open_or_stdin,
-};
+use crate::open_or_stdin;
 use crate::Config;
 use crate::SECONDS_IN_YEAR;
 use crate::parse_duration;
@@ -33,6 +31,8 @@ pub fn dispatch(config: Config, m: &clap::ArgMatches) -> Result<()> {
         ("dsm-import", Some(m)) => dsm_import(config, m)?,
         ("password", Some(m)) => password(config, m)?,
         ("extract-cert", Some(m)) => extract_cert(config, m)?,
+        ("info", Some(m)) => print_dsm_key_info(config, m)?,
+        ("list-dsm-keys", Some(m)) => list_dsm_keys(config, m)?,
         ("extract-dsm-secret", Some(m)) => extract_dsm(config, m)?,
         ("adopt", Some(m)) => adopt(config, m)?,
         ("attest-certifications", Some(m)) =>
@@ -323,6 +323,45 @@ fn _unlock(key: Cert) -> Result<Cert> {
                key.keys().unencrypted_secret().count());
 
     Ok(key)
+}
+
+fn print_dsm_key_info(_config: Config, m: &ArgMatches) -> Result<()> {
+    let dsm_secret = dsm::Auth::from_options_or_env(
+        m.value_of("api-key"),
+        m.value_of("client-cert"),
+        m.value_of("app-uuid"),
+        m.value_of("pkcs12-passphrase"),
+    )?;
+    let dsm_auth = dsm::Credentials::new(dsm_secret)?;
+
+    let output = match m.value_of("dsm-key") {
+        Some(key_name) => {
+            // Fortanix DSM
+            dsm::dsm_key_info(dsm_auth, key_name)?
+        },
+        None => return Err(anyhow::anyhow!(
+                "No Key name provided"))
+    };
+
+    print!("{}",output.iter().join("\n"));
+
+    Ok(())
+}
+
+fn list_dsm_keys(_config: Config, m: &ArgMatches) -> Result<()> {
+    let dsm_secret = dsm::Auth::from_options_or_env(
+        m.value_of("api-key"),
+        m.value_of("client-cert"),
+        m.value_of("app-uuid"),
+        m.value_of("pkcs12-passphrase"),
+    )?;
+    let dsm_auth = dsm::Credentials::new(dsm_secret)?;
+
+    let output = dsm::list_keys(dsm_auth, m.is_present("long"))?;
+
+    print!("{}",output.iter().join("\n"));
+
+    Ok(())
 }
 
 fn extract_cert(config: Config, m: &ArgMatches) -> Result<()> {

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -409,6 +409,8 @@
 //!             Imports a Transferable Secret Key into Fortanix DSM
 //!
 //!     attest-certifications    Attests to third-party certifications
+//!     info                     List details on DSM key
+//!     list-dsm-keys            List all accessible keys for the App
 //!     adopt                    Binds keys from one certificate to another
 //!     help
 //!             Prints this message or the help of the given subcommand(s)
@@ -766,6 +768,67 @@
 //!
 //! # Retract prior attestations on the key
 //! $ sq key attest-certifications --none juliet.pgp
+//! ```
+//!
+//! ### Subcommand key info
+//!
+//! ```text
+//!
+//! This command will print data on the given DSM key name if the key is present.
+//!
+//! USAGE:
+//!     sq key info --dsm-key <DSM-KEY-NAME>
+//!
+//! FLAGS:
+//!     -h, --help
+//!             Prints help information
+//!
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! OPTIONS:
+//!         --dsm-key <DSM-KEY-NAME>
+//!             Name of the DSM key
+//!
+//!
+//! EXAMPLES:
+//!
+//! # Prints details on given key
+//! $ sq key info --dsm-key 0123456789A
+//! ```
+//!
+//! ### Subcommand key list-dsm-keys
+//!
+//! ```text
+//!
+//! This command prints details about all the keys accessible to the app.
+//! Command will query DSM list keys API for each group, and club the outputs
+//! to print on STDOUT. Note that this command might cause delays after execution
+//! as it depends on multiple API calls depending on the distribution of keys
+//! in the account.
+//!
+//! USAGE:
+//!     sq key list-dsm-keys [FLAGS]
+//!
+//! FLAGS:
+//!     -h, --help
+//!             Prints help information
+//!
+//!     -l, --long
+//!             prints long details of key
+//!
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! EXAMPLES:
+//!
+//! # Print list of keys which app can access
+//! $ sq key list-dsm-keys
+//!
+//! # Print detailed list of keys which app can access
+//! $ sq key list-dsm-keys -l
 //! ```
 //!
 //! ### Subcommand key adopt

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -774,7 +774,7 @@
 //!
 //! ```text
 //!
-//! This command will print data on the given DSM key name if the key is present.
+//! This command prints data on a given DSM key name, if the key is present.
 //!
 //! USAGE:
 //!     sq key info --dsm-key <DSM-KEY-NAME>
@@ -804,9 +804,7 @@
 //!
 //! This command prints details about all the keys accessible to the app.
 //! Command will query DSM list keys API for each group, and club the outputs
-//! to print on STDOUT. Note that this command might cause delays after execution
-//! as it depends on multiple API calls depending on the distribution of keys
-//! in the account.
+//! to print on STDOUT.
 //!
 //! USAGE:
 //!     sq key list-dsm-keys [FLAGS]

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -912,7 +912,7 @@ $ sq key adopt --keyring juliet-old.pgp --key 0123456789ABCDEF -- juliet-new.pgp
                         .about("List details on DSM key")
                         .long_about(
 "
-This command will print data on the given DSM key name if the key is present.
+This command prints data on a given DSM key name, if the key is present.
 ")
                         .after_help(
 "EXAMPLES:
@@ -933,9 +933,7 @@ $ sq key info --dsm-key 0123456789A
 "
 This command prints details about all the keys accessible to the app.
 Command will query DSM list keys API for each group, and club the outputs
-to print on STDOUT. Note that this command might cause delays after execution
-as it depends on multiple API calls depending on the distribution of keys
-in the account.
+to print on STDOUT.
 ")
                         .after_help(
 "EXAMPLES:

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -907,6 +907,51 @@ $ sq key adopt --keyring juliet-old.pgp --key 0123456789ABCDEF -- juliet-new.pgp
                              .help("Emits binary data"))
                 )
                 .subcommand(
+                    SubCommand::with_name("info")
+                        .display_order(300)
+                        .about("List details on DSM key")
+                        .long_about(
+"
+This command will print data on the given DSM key name if the key is present.
+")
+                        .after_help(
+"EXAMPLES:
+
+# Prints details on given key
+$ sq key info --dsm-key 0123456789A
+")
+                        .arg(Arg::with_name("dsm-key")
+                             .long("dsm-key").value_name("DSM-KEY-NAME")
+                             .required(true)
+                             .help("Name of the DSM key"))
+                )
+                .subcommand(
+                    SubCommand::with_name("list-dsm-keys")
+                        .display_order(400)
+                        .about("List all accessible keys for the App")
+                        .long_about(
+"
+This command prints details about all the keys accessible to the app.
+Command will query DSM list keys API for each group, and club the outputs
+to print on STDOUT. Note that this command might cause delays after execution
+as it depends on multiple API calls depending on the distribution of keys
+in the account.
+")
+                        .after_help(
+"EXAMPLES:
+
+# Print list of keys which app can access
+$ sq key list-dsm-keys
+
+# Print detailed list of keys which app can access
+$ sq key list-dsm-keys -l
+")
+                        .arg(Arg::with_name("long")
+                             .short("l").long("long")
+                             .help("prints long details of key")
+                            )
+                )
+                .subcommand(
                     SubCommand::with_name("attest-certifications")
                         .display_order(200)
                         .about("Attests to third-party certifications")

--- a/sq/tests/dsm/print_dsm_key_info.sh
+++ b/sq/tests/dsm/print_dsm_key_info.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+sq=""
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $SCRIPT_DIR/common.sh
+
+random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
+
+array=( rsa2k rsa3k rsa4k nistp256 nistp384 nistp521 cv25519 )
+for alg in "${array[@]}"
+do
+	dsm_name="generate-knownkeys-test-$random-$alg"
+	user_id="Knownkey-Test-$alg (sq-dsm $v) <xyz@xyz.xyz>"
+	$sq key generate --userid="$user_id" --dsm-key="$dsm_name" --cipher-suite="$alg" --dsm-exportable
+	$sq key info --dsm-key="$dsm_name" | awk '{print}'
+done
+
+ldk_cmd_long_resp=$($sq key list-dsm-keys -l | tail -2 | head -1 | awk '{print $NF}')
+ldk_cmd_short_resp=$($sq key list-dsm-keys | tail -2 | head -1 | awk '{print $NF}')
+
+if [[ ! $ldk_cmd_short_resp -eq $ldk_cmd_short_resp ]]
+then
+	echo "long response objects($ldk_cmd_long_resp) != short response objects($ldk_cmd_short_resp)"
+	exit 1
+fi


### PR DESCRIPTION
### New Commands
- `sq key info` is a command for fetching details on key by its name (provided with `--dsm-key` arg). If keys with same name exists, it prints details on all of them.
- `sq key list-dsm-keys` is a commands for listing keys the app has access over. Verbosity on details of each key can be controlled by a feature flag `--long`. This command will only print details on PGP keys (i.e, keys with PGP metadata)

Features are added using readily available APIs