### PR TITLE
Allow rsa2k and nistp keys generation

### DIFF
--- a/sq/Makefile
+++ b/sq/Makefile
@@ -62,3 +62,10 @@ test-dsm:
 	./tests/dsm/sq_roundtrips.sh -c nistp384
 	./tests/dsm/sq_roundtrips.sh -c nistp521
 	./tests/dsm/sq_roundtrips.sh -c cv25519
+	./tests/local/generate_keys.sh -c rsa2k
+	./tests/local/generate_keys.sh -c rsa3k
+	./tests/local/generate_keys.sh -c rsa4k
+	./tests/local/generate_keys.sh -c nistp256
+	./tests/local/generate_keys.sh -c nistp384
+	./tests/local/generate_keys.sh -c nistp521
+	./tests/local/generate_keys.sh -c cv25519

--- a/sq/src/commands/key.rs
+++ b/sq/src/commands/key.rs
@@ -131,11 +131,23 @@ fn generate(config: Config, m: &ArgMatches) -> Result<()> {
 
     // Cipher Suite
     match m.value_of("cipher-suite") {
+        Some("rsa2k") => {
+            builder = builder.set_cipher_suite(CipherSuite::RSA2k);
+        }
         Some("rsa3k") => {
             builder = builder.set_cipher_suite(CipherSuite::RSA3k);
         }
         Some("rsa4k") => {
             builder = builder.set_cipher_suite(CipherSuite::RSA4k);
+        }
+        Some("nistp256") => {
+            builder = builder.set_cipher_suite(CipherSuite::P256);
+        }
+        Some("nistp384") => {
+            builder = builder.set_cipher_suite(CipherSuite::P384);
+        }
+        Some("nistp521") => {
+            builder = builder.set_cipher_suite(CipherSuite::P521);
         }
         Some("cv25519") => {
             builder = builder.set_cipher_suite(CipherSuite::Cv25519);

--- a/sq/tests/local/generate_keys.sh
+++ b/sq/tests/local/generate_keys.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+sq=""
+cipher_suite=""
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $SCRIPT_DIR/../dsm/common.sh
+
+# Create a temporary directory to store generated keys
+data=""
+create_tmp_dir data
+
+# Set up a trap to delete the temporary directory upon exit
+trap 'erase_tmp_dir $data' EXIT
+
+# Generate key locally with given cipher-suite
+$sq key generate --userid="Bob Сергeeвич Прокoфьев <bob@openpgp.example>" --cipher-suite="$cipher_suite" --export="$data/${cipher_suite}key"


### PR DESCRIPTION
Currently, the `cipher-suite` match check does not allow the generation of rsa2k & nistp keys. This pull request updates the match check to enable this functionality.