### PR TITLE
Added support for RSA 8K key generation in DSM

### DIFF
--- a/openpgp-dsm/src/lib.rs
+++ b/openpgp-dsm/src/lib.rs
@@ -680,6 +680,7 @@ pub fn generate_key(
         Some("rsa2k") => SupportedPkAlgo::Rsa(2048),
         Some("rsa3k") => SupportedPkAlgo::Rsa(3072),
         Some("rsa4k") => SupportedPkAlgo::Rsa(4096),
+        Some("rsa8k") => SupportedPkAlgo::Rsa(8192),
         Some("cv25519") => SupportedPkAlgo::Curve25519,
         Some("nistp256") => SupportedPkAlgo::Ec(ApiCurve::NistP256),
         Some("nistp384") => SupportedPkAlgo::Ec(ApiCurve::NistP384),

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -474,7 +474,7 @@
 //!             universal]
 //!     -c, --cipher-suite <CIPHER-SUITE>
 //!             Selects the cryptographic algorithms for the key [default: cv25519]
-//!             [possible values: rsa2k, rsa3k, rsa4k, cv25519, nistp256, nistp384,
+//!             [possible values: rsa2k, rsa3k, rsa4k, rsa8k, cv25519, nistp256, nistp384,
 //!             nistp521]
 //!         --client-cert <P12-FILE>
 //!             Authenticates to Fortanix DSM with the given client certificate

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -594,6 +594,7 @@ $ sq key generate --userid \"<juliet@example.org>\" --userid \"Juliet Capulet\"
                                  "rsa2k",
                                  "rsa3k",
                                  "rsa4k",
+                                 "rsa8k",
                                  "cv25519",
                                  "nistp256",
                                  "nistp384",

--- a/sq/tests/dsm/generate_knownkeys_for_version.sh
+++ b/sq/tests/dsm/generate_knownkeys_for_version.sh
@@ -21,7 +21,7 @@ versionkeys="$SCRIPT_DIR/../data/knownkeys/sq-dsm-$v"
 
 random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
 
-array=( rsa2k rsa3k rsa4k nistp256 nistp384 nistp521 cv25519 )
+array=( rsa2k rsa3k rsa4k rsa8k nistp256 nistp384 nistp521 cv25519 )
 for alg in "${array[@]}"
 do
     user_id="Knownkey-Test-$alg (sq-dsm $v) <xyz@xyz.xyz>"

--- a/sq/tests/dsm/print_dsm_key_info.sh
+++ b/sq/tests/dsm/print_dsm_key_info.sh
@@ -7,7 +7,7 @@ source $SCRIPT_DIR/common.sh
 
 random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
 
-array=( rsa2k rsa3k rsa4k nistp256 nistp384 nistp521 cv25519 )
+array=( rsa2k rsa3k rsa4k rsa8k nistp256 nistp384 nistp521 cv25519 )
 for alg in "${array[@]}"
 do
 	dsm_name="print-key-info-test-$random-$alg"


### PR DESCRIPTION
This PR adds support for RSA 8K key generation in DSM from sq-dsm.