### PR TITLE
Add support for importing & retrieving PGP keyrings & Version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openpgp-dsm"
-version = "1.9.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bindgen 0.57.0",

--- a/openpgp-dsm/Cargo.toml
+++ b/openpgp-dsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openpgp-dsm"
-version = "1.9.0"
+version = "2.0.0"
 authors = ["zugzwang <francisco.vialprado@fortanix.com>"]
 edition = "2018"
 

--- a/sq/src/commands/key.rs
+++ b/sq/src/commands/key.rs
@@ -378,7 +378,7 @@ fn _password(config: Config, m: &ArgMatches, key: Cert) -> Result<()> {
 }
 
 // Unlocks a cert with a passphrase
-fn _unlock(key: Cert) -> Result<Cert> {
+pub fn _unlock(key: Cert) -> Result<Cert> {
     if ! key.is_tsk() {
         return Err(anyhow::anyhow!("Input is not a Transferable Secret Key"));
     }
@@ -512,7 +512,7 @@ fn extract_cert(config: Config, m: &ArgMatches) -> Result<()> {
                 m.value_of("pkcs12-passphrase"),
             )?;
             let dsm_auth = dsm::Credentials::new(dsm_secret)?;
-            dsm::extract_cert(key_name, dsm_auth)?
+            dsm::extract_cert(key_name, dsm_auth, None)?
         }
         None => {
             let input = open_or_stdin(m.value_of("input"))?;
@@ -571,7 +571,7 @@ fn dsm_import(config: Config, m: &ArgMatches) -> Result<()> {
 
     match m.value_of("dsm-key") {
         Some(key_name) => dsm::import_key_to_dsm(
-            valid_key, key_name, group_id, dsm_auth, m.is_present("dsm-exportable"), user_metadata
+            valid_key, key_name, group_id, dsm_auth, m.is_present("dsm-exportable"), user_metadata, false
         ),
         None => unreachable!("name is compulsory")
     }
@@ -586,7 +586,7 @@ fn extract_dsm(config: Config, m: &ArgMatches) -> Result<()> {
     )?;
     let dsm_auth = dsm::Credentials::new(dsm_secret)?;
     let key = match m.value_of("dsm-key") {
-        Some(key_name) => dsm::extract_tsk_from_dsm(key_name, dsm_auth)?,
+        Some(key_name) => dsm::extract_tsk_from_dsm(key_name, dsm_auth, None)?,
         None => unreachable!("name is compulsory")
     };
 

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -944,15 +944,15 @@
 //!
 //!
 //! SUBCOMMANDS:
-//!     list              Lists keys in a keyring
-//!     split             Splits a keyring into individual keys
-//!     join              Joins keys or keyrings into a single keyring
-//!     create-keyring    Create keyrings from DSM Keys
-//!     dsm-import        Import keyrings into DSM
-//!     merge             Merges keys or keyrings into a single keyring
-//!     filter            Joins keys into a keyring applying a filter
-//!     help              Prints this message or the help of the given
-//!                       subcommand(s)
+//!     list          Lists keys in a keyring
+//!     split         Splits a keyring into individual keys
+//!     join          Joins keys or keyrings into a single keyring
+//!     dsm-import    Import keys from a keyring file into Fortanix DSM
+//!     extract       Extract keys from Fortanix DSM and export them as a
+//!                   keyring file.
+//!     merge         Merges keys or keyrings into a single keyring
+//!     filter        Joins keys into a keyring applying a filter
+//!     help          Prints this message or the help of the given subcommand(s)
 //! ```
 //!
 //! ### Subcommand keyring list
@@ -1074,46 +1074,10 @@
 //! $ sq keyring join juliet.pgp romeo.pgp alice.pgp
 //! ```
 //!
-//! ### Subcommand keyring create-keyring
-//!
-//! ```text
-//! Create keyrings from DSM Keys
-//!
-//! USAGE:
-//!     sq keyring create-keyring [FLAGS] [OPTIONS]
-//!
-//! FLAGS:
-//!     -B, --binary
-//!             Emits binary data
-//!
-//!     -h, --help
-//!             Prints help information
-//!
-//!         --public-only
-//!             Extract only Public keys from DSM
-//!
-//!     -V, --version
-//!             Prints version information
-//!
-//!
-//! OPTIONS:
-//!         --dsm-key-id <DSM-KEY-ID>...
-//!             DSM key ID's to create keyring
-//!
-//!     -o, --output <FILE>
-//!             Writes to FILE or stdout if omitted
-//!
-//!
-//! EXAMPLES:
-//!
-//! $ sq-dsm keyring create-keyring --dsm-key-id <DSM_KEY_ID> --dsm-key-id
-//! <DSM_KEY_ID> --output keyring.pgp
-//! ```
-//!
 //! ### Subcommand keyring dsm-import
 //!
 //! ```text
-//! Import keyrings into DSM
+//! Import keys from a keyring file into Fortanix DSM
 //!
 //! USAGE:
 //!     sq keyring dsm-import [FLAGS] [OPTIONS]
@@ -1131,18 +1095,57 @@
 //!
 //! OPTIONS:
 //!         --dsm-group-id <DSM-GROUP-ID>
-//!             Generate Keyring keys inside Fortanix DSM in the given group-id
+//!             Import Keyring keys into Fortanix DSM in the given group-id
 //!
 //!         --input <FILE>
 //!             Reads from FILE or stdin if omitted
 //!
 //!         --keyring-name <KEYRING-NAME>
-//!             Name to store the given keyring in DSM
+//!             Name of the keyring. Used to label(name) keys during import
 //!
 //!
 //! EXAMPLES:
 //!
 //! $ sq-dsm keyring dsm-import --keyring-name <keyring-name> --input keyring.pgp
+//! ```
+//!
+//! ### Subcommand keyring extract
+//!
+//! ```text
+//! Retrieves keys from Fortanix DSM using the specified key IDs and writes them to
+//! a keyring file.
+//! By default, only public keys are exported. Use --include-private to also export
+//! private keys also.
+//!
+//! USAGE:
+//!     sq keyring extract [FLAGS] [OPTIONS]
+//!
+//! FLAGS:
+//!     -B, --binary
+//!             Emits binary data
+//!
+//!     -h, --help
+//!             Prints help information
+//!
+//!         --include-private
+//!             By default, only public keys are exported. Use this flag to include
+//!             private keys in the exported keyring.
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! OPTIONS:
+//!         --dsm-key-id <DSM-KEY-ID>...
+//!             DSM key ID's to create keyring
+//!
+//!     -o, --output <FILE>
+//!             Writes to FILE or stdout if omitted
+//!
+//!
+//! EXAMPLES:
+//!
+//! $ sq-dsm keyring extract --dsm-key-id <DSM_KEY_ID> --dsm-key-id <DSM_KEY_ID>
+//! --output keyring.pgp
 //! ```
 //!
 //! ### Subcommand keyring merge

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -930,7 +930,7 @@
 //! Collections of keys or certficicates (also known as "keyrings" when
 //! they contain secret key material, and "certrings" when they don't) are
 //! any number of concatenated certificates.  This subcommand provides
-//! tools to list, split, join, merge, and filter keyrings.
+//! tools to dsm-import, list, split, join, merge, and filter keyrings.
 //!
 //! Note: In the documentation of this subcommand, we sometimes use the
 //! terms keys and certs interchangeably.
@@ -944,12 +944,15 @@
 //!
 //!
 //! SUBCOMMANDS:
-//!     list      Lists keys in a keyring
-//!     split     Splits a keyring into individual keys
-//!     join      Joins keys or keyrings into a single keyring
-//!     merge     Merges keys or keyrings into a single keyring
-//!     filter    Joins keys into a keyring applying a filter
-//!     help      Prints this message or the help of the given subcommand(s)
+//!     list              Lists keys in a keyring
+//!     split             Splits a keyring into individual keys
+//!     join              Joins keys or keyrings into a single keyring
+//!     create-keyring    Create keyrings from DSM Keys
+//!     dsm-import        Import keyrings into DSM
+//!     merge             Merges keys or keyrings into a single keyring
+//!     filter            Joins keys into a keyring applying a filter
+//!     help              Prints this message or the help of the given
+//!                       subcommand(s)
 //! ```
 //!
 //! ### Subcommand keyring list
@@ -1069,6 +1072,77 @@
 //!
 //! # Collect certs for an email conversation
 //! $ sq keyring join juliet.pgp romeo.pgp alice.pgp
+//! ```
+//!
+//! ### Subcommand keyring create-keyring
+//!
+//! ```text
+//! Create keyrings from DSM Keys
+//!
+//! USAGE:
+//!     sq keyring create-keyring [FLAGS] [OPTIONS]
+//!
+//! FLAGS:
+//!     -B, --binary
+//!             Emits binary data
+//!
+//!     -h, --help
+//!             Prints help information
+//!
+//!         --public-only
+//!             Extract only Public keys from DSM
+//!
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! OPTIONS:
+//!         --dsm-key-id <DSM-KEY-ID>...
+//!             DSM key ID's to create keyring
+//!
+//!     -o, --output <FILE>
+//!             Writes to FILE or stdout if omitted
+//!
+//!
+//! EXAMPLES:
+//!
+//! $ sq-dsm keyring create-keyring --dsm-key-id <DSM_KEY_ID> --dsm-key-id
+//! <DSM_KEY_ID> --output keyring.pgp
+//! ```
+//!
+//! ### Subcommand keyring dsm-import
+//!
+//! ```text
+//! Import keyrings into DSM
+//!
+//! USAGE:
+//!     sq keyring dsm-import [FLAGS] [OPTIONS]
+//!
+//! FLAGS:
+//!         --dsm-exportable
+//!             (DANGER) Configure the key to be exportable from DSM
+//!
+//!     -h, --help
+//!             Prints help information
+//!
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! OPTIONS:
+//!         --dsm-group-id <DSM-GROUP-ID>
+//!             Generate Keyring keys inside Fortanix DSM in the given group-id
+//!
+//!         --input <FILE>
+//!             Reads from FILE or stdin if omitted
+//!
+//!         --keyring-name <KEYRING-NAME>
+//!             Name to store the given keyring in DSM
+//!
+//!
+//! EXAMPLES:
+//!
+//! $ sq-dsm keyring dsm-import --keyring-name <keyring-name> --input keyring.pgp
 //! ```
 //!
 //! ### Subcommand keyring merge

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -1217,8 +1217,8 @@ $ sq keyring merge certs.pgp romeo-updates.pgp
                 .subcommand(
                     SubCommand::with_name("dsm-import")
                         .display_order(350)
-                        .about("Import keyrings into DSM")
-                        .long_about("Import keyrings into DSM")
+                        .about("Import keys from a keyring file into Fortanix DSM")
+                        .long_about("Import keys from a keyring file into Fortanix DSM")
                         .after_help(
 "EXAMPLES:
 
@@ -1226,7 +1226,7 @@ $ sq-dsm keyring dsm-import --keyring-name <keyring-name> --input keyring.pgp
 ")
                         .arg(Arg::with_name("keyring-name")
                              .long("keyring-name").value_name("KEYRING-NAME")
-                             .help("Name to store the given keyring in DSM"))
+                             .help("Name of the keyring. Used to label(name) keys during import"))
                         .arg(Arg::with_name("dsm-exportable")
                             .long("dsm-exportable")
                             .help("(DANGER) Configure the key to be exportable from DSM"))
@@ -1235,19 +1235,19 @@ $ sq-dsm keyring dsm-import --keyring-name <keyring-name> --input keyring.pgp
                                  .help("Reads from FILE or stdin if omitted"))
                         .arg(Arg::with_name("dsm-group-id")
                              .long("dsm-group-id").value_name("DSM-GROUP-ID")
-                             .help("Generate Keyring keys inside Fortanix DSM in \
-                             the given group-id")
+                             .help("Import Keyring keys into Fortanix DSM in the given group-id")
                              .requires("keyring-name"))
                 )
                 .subcommand(
-                    SubCommand::with_name("create-keyring")
+                    SubCommand::with_name("extract")
                         .display_order(350)
-                        .about("Create keyrings from DSM Keys")
-                        .long_about("Create keyrings from DSM Keys")
+                        .about("Extract keys from Fortanix DSM and export them as a keyring file.")
+                        .long_about("Retrieves keys from Fortanix DSM using the specified key IDs and writes them to a keyring file. 
+By default, only public keys are exported. Use --include-private to also export private keys also.")
                         .after_help(
 "EXAMPLES:
 
-$ sq-dsm keyring create-keyring --dsm-key-id <DSM_KEY_ID> --dsm-key-id <DSM_KEY_ID> --output keyring.pgp 
+$ sq-dsm keyring extract --dsm-key-id <DSM_KEY_ID> --dsm-key-id <DSM_KEY_ID> --output keyring.pgp 
 ")
                         .arg(Arg::with_name("dsm-key-id")
                              .long("dsm-key-id").value_name("DSM-KEY-ID")
@@ -1255,9 +1255,9 @@ $ sq-dsm keyring create-keyring --dsm-key-id <DSM_KEY_ID> --dsm-key-id <DSM_KEY_
                              .multiple(true)
                              .number_of_values(1)
                              .help("DSM key ID's to create keyring"))
-                        .arg(Arg::with_name("public-only")
-                            .long("public-only")
-                            .help("Extract only Public keys from DSM"))
+                        .arg(Arg::with_name("include-private")
+                             .long("include-private")
+                             .help("By default, only public keys are exported. Use this flag to include private keys in the exported keyring."))
                         .arg(Arg::with_name("binary")
                              .short("B").long("binary")
                              .help("Emits binary data"))

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -1054,7 +1054,7 @@ $ sq key attest-certifications --none juliet.pgp
 Collections of keys or certficicates (also known as \"keyrings\" when
 they contain secret key material, and \"certrings\" when they don't) are
 any number of concatenated certificates.  This subcommand provides
-tools to list, split, join, merge, and filter keyrings.
+tools to dsm-import, list, split, join, merge, and filter keyrings.
 
 Note: In the documentation of this subcommand, we sometimes use the
 terms keys and certs interchangeably.
@@ -1214,6 +1214,57 @@ $ sq keyring merge certs.pgp romeo-updates.pgp
                              .short("B").long("binary")
                              .help("Emits binary data"))
                 )
+                .subcommand(
+                    SubCommand::with_name("dsm-import")
+                        .display_order(350)
+                        .about("Import keyrings into DSM")
+                        .long_about("Import keyrings into DSM")
+                        .after_help(
+"EXAMPLES:
+
+$ sq-dsm keyring dsm-import --keyring-name <keyring-name> --input keyring.pgp 
+")
+                        .arg(Arg::with_name("keyring-name")
+                             .long("keyring-name").value_name("KEYRING-NAME")
+                             .help("Name to store the given keyring in DSM"))
+                        .arg(Arg::with_name("dsm-exportable")
+                            .long("dsm-exportable")
+                            .help("(DANGER) Configure the key to be exportable from DSM"))
+                        .arg(Arg::with_name("input")
+                                 .long("input").value_name("FILE")
+                                 .help("Reads from FILE or stdin if omitted"))
+                        .arg(Arg::with_name("dsm-group-id")
+                             .long("dsm-group-id").value_name("DSM-GROUP-ID")
+                             .help("Generate Keyring keys inside Fortanix DSM in \
+                             the given group-id")
+                             .requires("keyring-name"))
+                )
+                .subcommand(
+                    SubCommand::with_name("create-keyring")
+                        .display_order(350)
+                        .about("Create keyrings from DSM Keys")
+                        .long_about("Create keyrings from DSM Keys")
+                        .after_help(
+"EXAMPLES:
+
+$ sq-dsm keyring create-keyring --dsm-key-id <DSM_KEY_ID> --dsm-key-id <DSM_KEY_ID> --output keyring.pgp 
+")
+                        .arg(Arg::with_name("dsm-key-id")
+                             .long("dsm-key-id").value_name("DSM-KEY-ID")
+                             .takes_value(true)
+                             .multiple(true)
+                             .number_of_values(1)
+                             .help("DSM key ID's to create keyring"))
+                        .arg(Arg::with_name("public-only")
+                            .long("public-only")
+                            .help("Extract only Public keys from DSM"))
+                        .arg(Arg::with_name("binary")
+                             .short("B").long("binary")
+                             .help("Emits binary data"))
+                        .arg(Arg::with_name("output")
+                             .short("o").long("output").value_name("FILE")
+                             .help("Writes to FILE or stdout if omitted"))
+               )
                 .subcommand(
                     SubCommand::with_name("list")
                         .about("Lists keys in a keyring")


### PR DESCRIPTION
This PR adds 
### Features :
1. Import Keyring  => `sq-dsm keyring dsm-import --dsm-exportable --keyring-name "<KEYRING-NAME>" --input <KEYRING-FILE> --dsm-group-id <DSM-GROUP-UUID>`
2. Retrieve Keyring => `sq-dsm keyring extract --dsm-key-id <DSM-KEY-UUID> --dsm-key-id <DSM-KEY-UUID> --output <KEYRING-FILE> --include-private`

### Version bump :
bumps version from sq-dsm 1.9.0 => 2.0.0